### PR TITLE
do not hardcode the path to python, so python3.6 works

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     name: pulpcore
     state: present
     virtualenv: "{{ pulp_venv }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+    virtualenv_command: "{{ ansible_python_interpreter }} -m venv"
   become_user: "{{ pulp_user }}"
 
 - name: Add Django supplemental bashrc


### PR DESCRIPTION
some distributions like CentOS use binaries named like `python3.6`/`python36`. Using a hardcoded `python3` binary crashes in that case. `ansible_python_interpreter` is configured to _some_ valid python interpreter, which should be py3 for pulp.