### PR TITLE
Do not hard-code path to nologin executable

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,10 +6,16 @@
   with_items: '{{ pulp_preq_packages }}'
   when: pulp_install_prerequisites | bool()
 
+- name: Find the nologin executable
+  command: which nologin
+  changed_when: False
+  check_mode: False
+  register: result
+
 - name: Create user {{ pulp_user }}
   user:
     name: "{{ pulp_user }}"
-    shell: /bin/nologin
+    shell: "{{ result.stdout.strip() }}"
     home: '{{ pulp_var_dir }}'
     comment: "Pulp user"
 


### PR DESCRIPTION
One of the tasks creates a user with a shell of `/bin/nologin`. This is
problematic, because the `nologin` executable may not be at that path.
For example, on Fedora 26 and 27, it's present at `/usr/sbin/nologin`.
On Arch Linux, it's available at `/usr/bin/nologin`.

Do not hard-code the path to the `nologin` executable. Discover the path
to this executable at runtime instead.