### PR TITLE
Install and configure an AMQP broker

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,3 +44,6 @@ pulp_workers:
   2:
     state: started
     enabled: true
+
+pulp_broker_state: started
+pulp_broker_enabled: true

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Install RabbitMQ
+  package:
+    name: rabbitmq-server
+    state: present
+
+- name: Start and enable RabbitMQ
+  systemd:
+    name: rabbitmq-server
+    state: '{{ pulp_broker_state }}'
+    enabled: '{{ pulp_broker_enabled }}'
+    daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,4 +13,5 @@
 - import_tasks: install.yml
 - import_tasks: configure.yml
 - import_tasks: database.yml
+- import_tasks: broker.yml
 - import_tasks: service.yml


### PR DESCRIPTION
An AMQP broker is necessary for Pulp to function. Install, start, and
enable RabbitMQ.