### PR TITLE
Standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ before_install:
 
 # Install molecule and docker-py
 install:
-  - pip install tox-travis
+  - pip install tox-travis ansible-review==0.13.4
 
 # Test all the scenarios against the Ansible versions defined in the tox.ini file
 script:
+  - tox -e standards
   - tox
+

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -14,8 +14,8 @@ rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash which && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash which && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash which selinux-policy firewalld&& dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash which selinux-policy firewalld&& sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,6 +3,8 @@
   become: true
   vars:
     pulp_config_secret_key: secret
+    pulp_default_admin_password: ''
+    ansible_python_interpreter: /usr/bin/python3
   pre_tasks:
     - name: Require Ansible 2.4+
       assert:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -15,7 +15,5 @@
           and installing Ansible with pip.
   roles:
     - pulp3-redis
-    - name: pulp3
-      vars:
-        pulp_default_admin_password: 'password'
+    - pulp3
     - pulp3-webserver

--- a/roles/pulp3/tasks/install.yml
+++ b/roles/pulp3/tasks/install.yml
@@ -1,15 +1,15 @@
 ---
-- name: Disable SELinux (Pulp 3 is currently incompatible with SELinux)
-  selinux:
-    policy: targeted
-    state: permissive
-
 - name: Install prerequisites
   package:
     name: '{{ item }}'
     state: installed
   with_items: '{{ pulp_preq_packages }}'
   when: pulp_install_prerequisites | bool()
+
+- name: Disable SELinux (Pulp 3 is currently incompatible with SELinux)
+  selinux:
+    policy: targeted
+    state: permissive
 
 - name: Find the nologin executable
   command: which nologin

--- a/roles/pulp3/vars/RedHat.yml
+++ b/roles/pulp3/vars/RedHat.yml
@@ -3,5 +3,6 @@ pulp_preq_packages:
   - python3
   - python3-devel
   - libselinux-python  # For ansible itself
+  - python3-libselinux
 
 pulp_psycopg_package: 'python{{ ansible_python.version.major }}-psycopg2'

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,10 @@ deps =
     ansible25: ansible==2.5
 commands =
     molecule test
+
+[testenv:standards]
+whitelist_externals = bash
+deps = ansible-review==0.13.4
+commands =
+  bash -c "git ls-files | grep '\.yml$' | xargs -I {} ansible-review {} | egrep --color 'WARN|^' && exit 1"
+

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = true
 passenv = *
 deps =
     -rrequirements.txt
-    ansible24: ansible==2.4.0.0
-    ansible25: ansible==2.5.0.0
+    ansible24: ansible==2.4.4
+    ansible25: ansible==2.5
 commands =
     molecule test


### PR DESCRIPTION
Add ansible-rewiew to Tox and Travis CI to test Ansible standards.
Depends on #10 

Example results:
https://travis-ci.org/abraverm/ansible-pulp3/builds/392172705

Notes:
This currently test all `yml` files but once roles will be managed with galaxy we will set it up for each role individually and for this repo it will only test the playbooks.