### PR TITLE
Call pulp3-workers role from molecule playbook

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -8,4 +8,5 @@
   roles:
     - pulp3-redis
     - pulp3
+    - pulp3-workers
     - pulp3-webserver


### PR DESCRIPTION
The molecule playbook is missing the call to this role simply because it
was written before this role was created.