### PR TITLE
WIP: Let pulp_default_admin_password be empty string

### DIFF
--- a/roles/pulp3/tasks/database.yml
+++ b/roles/pulp3/tasks/database.yml
@@ -94,4 +94,4 @@
   become: true
   become_user: '{{ pulp_user }}'
   no_log: True
-  when: pulp_default_admin_password
+  when: pulp_default_admin_password is defined


### PR DESCRIPTION
TODO: Figure out how to show changed status only when password changes.

Do set the Pulp admin user's password any time the
`pulp_default_admin_password` variable is defined. This is useful: a
user might want to set the Pulp admin user's password to any number of
values, including an empty string (as unwise as this might be).