### PR TITLE
Make pulp3-workers depend on pulp3-redis

### DIFF
--- a/roles/pulp3-workers/meta/main.yml
+++ b/roles/pulp3-workers/meta/main.yml
@@ -9,4 +9,5 @@ galaxy_info:
     versions:
     - 28
   license: GPL-3.0
-dependencies: []
+dependencies:
+- pulp3-redis


### PR DESCRIPTION
This dependency was declared when the pulp3-workers role was created, in
d64513d9f91f98586c1adea402cebb4fcca70ec8, and a later commit
accidentally dropped this dependency declaration.