### PR TITLE
Test against Fedora 27

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ lint:
   enabled: False
 platforms:
   - name: instance
-    image: fedora
+    image: fedora:27
     privileged: True
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/roles/pulp3/vars/RedHat.yml
+++ b/roles/pulp3/vars/RedHat.yml
@@ -3,6 +3,5 @@ pulp_preq_packages:
 - python3
 - python3-devel
 - libselinux-python  # For ansible itself
-- python3-libselinux
 
 pulp_psycopg_package: 'python{{ ansible_python.version.major }}-psycopg2'


### PR DESCRIPTION
- specify version of Fedora in Molecule platforms
- remove python3-libselinux as it only exists on Fedora 28 (not-supported)