### PR TITLE
Drop unnecessary call to pulp3-redis role

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,7 +6,6 @@
     pulp_default_admin_password: ''
     ansible_python_interpreter: /usr/bin/python3
   roles:
-    - pulp3-redis
     - pulp3
     - pulp3-workers
     - pulp3-webserver


### PR DESCRIPTION
Other roles (such as pulp3-workers) declare a dependency on the
pulp3-redis role through their "meta" information. As a result, it's
unnecessary to call this role from a playbook, because Ansible's
dependency resolution logic will call it anyway.