### PR TITLE
Revamp how linting is done

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
-	@echo "  help               to show this message"
-	@echo "  lint               to run all linters"
-	@echo "  lint-ansible-lint  to run ansible-lint"
-	@echo "  lint-syntax-check  to run ansible-playbook --syntax-check"
+	@echo "  help                 to show this message"
+	@echo "  lint                 to run all linters"
+	@echo "  lint-ansible-lint    to run ansible-lint"
+	@echo "  lint-syntax-check    to run ansible-playbook --syntax-check"
+	@echo "  lint-ansible-review  to run ansible-review"
 
-lint: lint-syntax-check lint-ansible-lint
+lint: lint-syntax-check lint-ansible-lint lint-ansible-review
 
 lint-syntax-check:
 	ansible-playbook deploy-pulp3.yml --syntax-check
@@ -13,4 +14,7 @@ lint-syntax-check:
 lint-ansible-lint:
 	ansible-lint deploy-pulp3.yml
 
-.PHONY: help lint
+lint-ansible-review:
+	find roles -type f -name '*.yml' -print0 | xargs -0 ansible-review
+
+.PHONY: help lint lint-syntax-check lint-ansible-lint lint-ansible-review

--- a/tox.ini
+++ b/tox.ini
@@ -16,5 +16,4 @@ commands =
 whitelist_externals = bash
 deps = ansible-review==0.13.4
 commands =
-  bash -c "git ls-files | grep '\.yml$' | grep -v travis | grep -v molecule | xargs -I {} ansible-review {} | egrep --color 'WARN|^' && exit 1 || exit 0"
-
+  bash -c 'make lint'


### PR DESCRIPTION
Add a new make target, `lint-ansible-review`, which calls
ansible-review.

Make tox perform linting by calling `make lint` instead of running
custom commands, so that the various bits of linting code are DRY. As a
bonus, a user can locally run `make lint` before pushing to Travis,
which shortens the feedback loop when developing.

Change how `ansible-review` is called:

* Don't suppress warning messages. They provide useful information, and
  they don't cause non-zero exit codes which unnecessarily break
  automated testing on Travis.
* Simplify the logic for finding files to be linted.