### PR TITLE
Add ansible-review config and standards file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 
 language: python
-python: 2.7
+python: 3.6
 
 sudo: required
 
@@ -14,7 +14,7 @@ before_install:
 
 # Install molecule and docker-py
 install:
-  - pip install tox-travis ansible-review==0.13.4
+  - pip install tox-travis
 
 # Test all the scenarios against the Ansible versions defined in the tox.ini file
 script:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ lint-ansible-lint:
 	ansible-lint deploy-pulp3.yml
 
 lint-ansible-review:
-	find roles -type f -name '*.yml' -print0 | xargs -0 ansible-review
+	find roles -type f -name '*.yml' -print0 | xargs -0 ansible-review -c ansible-review-config.ini
 
 .PHONY: help lint lint-syntax-check lint-ansible-lint lint-ansible-review

--- a/ansible-review-config.ini
+++ b/ansible-review-config.ini
@@ -1,0 +1,2 @@
+[rules]
+standards = ansible-review-standards

--- a/ansible-review-standards/standards.py
+++ b/ansible-review-standards/standards.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# coding=utf-8
+from ansiblereview.examples.standards import standards

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,6 @@ commands =
 
 [testenv:standards]
 whitelist_externals = bash
-deps = ansible-review==0.13.4
+deps = ansible-review==0.13.6
 commands =
   bash -c 'make lint'


### PR DESCRIPTION
Add an ansible-review standards file, which simply defines all the same
standards as the example ansible-review standards. Also add an
ansible-review configuration file, which references the just-created
standards file.

This setup is somewhat fragile: if the example standards provided by
ansible-review change, then linting might break without warning. Given
this, why even bother to add these files? Two reasons:

* ansible-review no longer complains about a lack of a user-provided
  configuration file, which lets us focus on the other, more important
  messages emitted by ansible-review.
* It's now easy to blacklist ansible-review standards that we don't
  like, or to add custom standards.

Also:

* Bump the version of ansible-review pulled in by tox, so that the
  imports in the new `standards.py` file work correctly.
* Don't install ansible-review in `.travis.yml`, as tox installs all of
  the ansible-review code that it needs anyway. Better to be DRY.
* Perform testing with Python 3.6, not 2.7, for several reasons:

  * Python 2 is going the way of the dodo.
  * The new `standards.py` file is only compatible with Python 3.

  Support for Python 3.5 and older may be added in the future.