### PR TITLE
Rewrite pulp 3 database tasks

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,7 +3,7 @@
   become: true
   vars:
     pulp_config_secret_key: secret
-    pulp_default_admin_password: ''
+    pulp_default_admin_password: 'password'
     ansible_python_interpreter: /usr/bin/python3
   roles:
     - pulp3-redis

--- a/roles/pulp3/defaults/main.yml
+++ b/roles/pulp3/defaults/main.yml
@@ -8,9 +8,6 @@ pulp_install_prerequisites: true
 
 pulp_python_interpreter: '{% if ansible_python_interpreter is defined %}{{ ansible_python_interpreter }}{% else %}/usr/bin/python3{% endif %}'
 
-pulp_database_migrate: true
-pulp_default_admin_password: ''
-
 pulp_config_dir: '/etc/pulp'
 pulp_var_dir: '/var/lib/pulp'
 pulp_cache_dir: '/var/cache/pulp'

--- a/roles/pulp3/tasks/database.yml
+++ b/roles/pulp3/tasks/database.yml
@@ -8,15 +8,19 @@
     state: directory
     mode: 0750
   when: pulp_config_database['default']['ENGINE'] == 'django.db.backends.sqlite3'
+  become: true
 
 - block:
+
   - name: Install psycopg package
     package:
       name: '{{ pulp_psycopg_package }}'
       state: installed
+    become: true
 
+  # The database is remote
   - block:
-    # The database is remote
+
     - name: Add Pulp database user
       postgresql_user:
         name: "{{ pulp_config_database['default']['USER'] }}"
@@ -35,63 +39,79 @@
         login_user: '{{ pulp_postgres_login_user }}'
         login_password: '{{ pulp_postgres_login_password }}'
         port: '{{ pulp_postgres_port }}'
-    when: pulp_config_database['default']['HOST'] is defined and pulp_config_database['default']['HOST'] != 'localhost'
 
+    when:
+    - pulp_config_database['default']['HOST'] is defined
+    - pulp_config_database['default']['HOST'] != 'localhost'
+
+  # The database is local
   - block:
-    # The database is local
+
     - name: Add Pulp database user
       postgresql_user:
         name: "{{ pulp_config_database['default']['USER'] }}"
         password: "{{ pulp_config_database['default']['PASSWORD'] }}"
         role_attr_flags: SUPERUSER,LOGIN
-      become: yes
-      become_user: '{{ pulp_postgres_user }}'
 
     - name: Add Pulp database
       postgresql_db:
         name: "{{ pulp_config_database['default']['NAME'] }}"
         owner: "{{ pulp_config_database['default']['USER'] }}"
-      become: yes
-      become_user: '{{ pulp_postgres_user }}'
-    when: pulp_config_database['default']['HOST'] is not defined or (pulp_config_database['default']['HOST'] is defined and pulp_config_database['default']['HOST'] == 'localhost')
-  when: pulp_config_database['default']['ENGINE'] in ['django.db.backends.postgresql_psycopg2', 'django.db.backends.postgresql']
+
+    become: true
+    become_user: '{{ pulp_postgres_user }}'
+    when: >
+      pulp_config_database['default']['HOST'] is not defined or
+      (pulp_config_database['default']['HOST'] is defined and pulp_config_database['default']['HOST'] == 'localhost')
+
+  when: >
+    pulp_config_database['default']['ENGINE'] in
+    ['django.db.backends.postgresql_psycopg2', 'django.db.backends.postgresql']
+
+- name: Get the exact pulpcore install dir
+  find:
+    paths: '{{ pulp_install_dir }}/lib/'
+    pattern: '^python.\..$'
+    use_regex: true
+    file_type: directory
+  register: result
+
+- name: Assert the pulpcore install dir was found
+  assert:
+    that: '{{ result.matched }} == 1'
+
+- name: Make the migrations directories writable for the {{ pulp_user }} user
+  file:
+    name: '{{ result.files[0].path }}/site-packages/{{ item }}/app/migrations'
+    state: directory
+    owner: '{{ pulp_user }}'
+    group: '{{ pulp_user }}'
+    mode: 0700
+  with_items: "{{ ['pulpcore'] | union(pulp_install_plugins) }}"
+  become: true
 
 - block:
-  - name: Get the exact pulpcore install dir
-    shell: 'ls -d {{ pulp_install_dir }}/lib/python?.?'
-    register: pulp_full_libdir
-    changed_when: False
-    check_mode: no
-
-  - name: Make the migrations directories writable for the {{ pulp_user }} user
-    file:
-      name: '{{ pulp_full_libdir.stdout_lines[0] }}/site-packages/{{ item }}/app/migrations'
-      state: directory
-      owner: '{{ pulp_user }}'
-      group: '{{ pulp_user }}'
-      mode: 0700
-    with_items: "{{ ['pulpcore'] | union(pulp_install_plugins) }}"
 
   - name: Create database migrations for pulp_app
     command: '{{ pulp_install_dir }}/bin/pulp-manager makemigrations {{ item }}'
-    changed_when: False
-    become: true
-    become_user: '{{ pulp_user }}'
     with_items: "{{ ['pulp_app'] | union(pulp_install_plugins) }}"
+    changed_when: False
+
+  - name: Run database auth migrations
+    command: '{{ pulp_install_dir }}/bin/pulp-manager migrate auth --no-input'
+    register: result
+    changed_when: "'No migrations to apply' not in result.stdout"
 
   - name: Run database migrations
-    command: '{{ pulp_install_dir }}/bin/pulp-manager {{ item }} --no-input'
-    become: true
-    become_user: '{{ pulp_user }}'
-    changed_when: False
-    with_items:
-    - 'migrate auth'
-    - 'migrate'
-  when: pulp_database_migrate | bool()
+    command: '{{ pulp_install_dir }}/bin/pulp-manager migrate --no-input'
+    register: result
+    changed_when: "'No migrations to apply' not in result.stdout"
 
-- name: Set the Super User's password
-  command: '{{ pulp_install_dir }}/bin/pulp-manager reset-admin-password --password {{ pulp_default_admin_password }}'
+  - name: Set the Pulp admin user's password
+    command: '{{ pulp_install_dir }}/bin/pulp-manager reset-admin-password --password {{ pulp_default_admin_password }}'
+    no_log: True
+    when: pulp_default_admin_password is defined
+    changed_when: False
+
   become: true
   become_user: '{{ pulp_user }}'
-  no_log: True
-  when: pulp_default_admin_password


### PR DESCRIPTION
The pulp 3 database tasks are non-idempotent:

* When the `pulp_database_migrate` variable is true, several database
  migrations commands run, and when these database migrations commands
  run, they always return a "changed" status. Fix this by doing two
  things:

  * Drop this variable, and always run database migrations. There's no
    harm in repeatedly running them.
  * Only report a "changed" status when the migrations runner reports
    than something has changed.

* Do not report a "changed" status when setting the Pulp admin user's
  password. This isn't ideal, as this task might actually change the
  Pulp admin user's password! But there's no good known solution for
  finding out whether this task changes the state of the target host,
  and letting this reporting bug slide allows us to move forward with
  other goals.

Also:

* Apply "become" to certain tasks, so that they no longer implicitly
  rely on the Ansible user being root, or otherwise having certain
  permissions.
* Find the pulpcore install directory using the "find" module instead of
  the "shell" module, and explicitly assert that this directory was
  found. This is a much more robust solution than relying on the
  vagaries of the target system, such as which directories are matched
  by the shell's globbing, and the features of the shell the happens to
  be chosen by Ansible.