### PR TITLE
Don't unnecessarily install ANXS.postgresql

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,10 @@ envlist = py{27,36}
 # into the virtualenvs tox creates.
 skipsdist = true
 
-# `ansible-review-standards/standards.py` fails to execute on Python 2.7, due to
-# how its import system works.
 [testenv]
-commands =
-    ansible-galaxy install git+https://github.com/ANXS/postgresql.git,,ANXS.postgresql
-    molecule test
 deps =
     ansible
     docker-py
     molecule
+commands =
+    molecule test


### PR DESCRIPTION
Molecule will install ANXS.postgresql as needed. It's pointless and
confusing to also install it with tox.