### PR TITLE
Don't provide a default SECRET_KEY for server.yaml

### DIFF
--- a/roles/pulp3/defaults/main.yml
+++ b/roles/pulp3/defaults/main.yml
@@ -7,7 +7,6 @@ pulp_default_admin_password: ''
 pulp_install_dir: '/opt/pulp'
 pulp_install_plugins: []
 pulp_install_service_files: true
-pulp_secret_key: ''
 pulp_user: pulp
 pulp_var_dir: '/var/lib/pulp'
 pulp_wsgi_enabled: true


### PR DESCRIPTION
Providing insecure default values is a Bad Idea.