### PR TITLE
Use systemd module

### DIFF
--- a/roles/pulp3-workers/tasks/main.yml
+++ b/roles/pulp3-workers/tasks/main.yml
@@ -9,7 +9,8 @@
   become: true
 
 - name: Set states of pulp workers
-  service:
+  systemd:
+    daemon_reload: true
     name: pulp_worker@{{ item.key }}.service
     state: '{{ item.value.state }}'
     enabled: '{{ item.value.enabled }}'


### PR DESCRIPTION
Use the systemd module instead of the service module for all service
management. Do this because the "systemd" module lets us do things with
the systemd daemon that the more generic "service" module. For example,
it lets us reload the systemd daemon right before changing the state of
services, which in turn prevents certain subtle bugs.

All of the platforms we're targeting use systemd.