### PR TITLE
Enable yamllint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ services:
 language: python
 matrix:
   include:
-  - python: 2.7
-    env: TOXENV=py27
-  - python: 3.6
-    env: TOXENV=py36
-  - python: 3.7
-    env: TOXENV=py37
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
 install:
   - pip install --upgrade pip
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+---
 # Molecule runs tests in containers.
 sudo: required
 services:
-- docker
+  - docker
 
 # Manually defining a build matrix is more cumbersome than using a tool like
 # tox-travis. However, this avoids adding yet another layer of abstraction, and
@@ -10,12 +11,12 @@ services:
 language: python
 matrix:
   include:
-  - python: 2.7
-    env: TOXENV=py27
-  - python: 3.6
-    env: TOXENV=py36
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
 install:
-- pip install --upgrade pip
-- pip install tox
+  - pip install --upgrade pip
+  - pip install tox
 script:
-- tox
+  - tox

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,6 @@ driver:
   name: docker
 lint:
   name: yamllint
-  enabled: false
 platforms:
   - name: centos-7
     image: centos:7

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,4 @@
+---
 - src: https://github.com/ANXS/postgresql
   version: master
   name: ANXS.postgresql

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,3 +1,4 @@
+---
 # This is an example playbook to execute inspec tests.
 # Tests need distributed to the appropriate ansible host/groups
 # prior to execution by `inspec exec`.

--- a/roles/pulp3-postgresql/defaults/main.yml
+++ b/roles/pulp3-postgresql/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 pulp_postgresql_call_anxs_postgresql: true
 pulp_database_config:
   default:

--- a/roles/pulp3-postgresql/meta/main.yml
+++ b/roles/pulp3-postgresql/meta/main.yml
@@ -1,4 +1,3 @@
-# Standards: 0.1
 ---
 galaxy_info:
   author: Pulp Team
@@ -8,13 +7,13 @@ galaxy_info:
   company: Red Hat
   min_ansible_version: 2.2
   platforms:
-  - name: Fedora
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - stretch
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - stretch
   galaxy_tags:
-  - pulp3
+    - pulp3
 dependencies:
-- pulp3
+  - pulp3

--- a/roles/pulp3-postgresql/tasks/main.yml
+++ b/roles/pulp3-postgresql/tasks/main.yml
@@ -1,21 +1,22 @@
+---
 - name: Load OS specific variables
   include_vars: '{{ ansible_distribution }}.yml'
   tags:
-  - always
+    - always
 
 - block:
 
-  # See: https://github.com/ANXS/postgresql/pull/371
-  - name: Install psycopg package
-    package:
-      name: '{{ pulp_psycopg_package }}'
-      state: present
+    # See: https://github.com/ANXS/postgresql/pull/371
+    - name: Install psycopg package
+      package:
+        name: '{{ pulp_psycopg_package }}'
+        state: present
 
-  # See: https://github.com/ANXS/postgresql/pull/376
-  - name: Install and configure PostgreSQL
-    import_role:
-      name: ANXS.postgresql
-    when: pulp_postgresql_call_anxs_postgresql
+    # See: https://github.com/ANXS/postgresql/pull/376
+    - name: Install and configure PostgreSQL
+      import_role:
+        name: ANXS.postgresql
+      when: pulp_postgresql_call_anxs_postgresql
 
   become: true
 
@@ -33,35 +34,35 @@
 
 - block:
 
-  - name: Create the migrations directory
-    file:
-      name: '{{ result.files[0].path }}/site-packages/{{ item }}/app/migrations'
-      state: directory
-      owner: '{{ pulp_user }}'
-      group: '{{ pulp_user }}'
-      mode: 0700
-    with_items: "{{ ['pulpcore'] | union(pulp_install_plugins) }}"
+    - name: Create the migrations directory
+      file:
+        name: '{{ result.files[0].path }}/site-packages/{{ item }}/app/migrations'
+        state: directory
+        owner: '{{ pulp_user }}'
+        group: '{{ pulp_user }}'
+        mode: 0700
+      with_items: "{{ ['pulpcore'] | union(pulp_install_plugins) }}"
 
-  - name: Create database migrations for pulp_app
-    command: '{{ pulp_install_dir }}/bin/pulp-manager makemigrations {{ item }}'
-    with_items: "{{ ['pulp_app'] | union(pulp_install_plugins) }}"
-    changed_when: False
+    - name: Create database migrations for pulp_app
+      command: '{{ pulp_install_dir }}/bin/pulp-manager makemigrations {{ item }}'
+      with_items: "{{ ['pulp_app'] | union(pulp_install_plugins) }}"
+      changed_when: False
 
-  - name: Run database auth migrations
-    command: '{{ pulp_install_dir }}/bin/pulp-manager migrate auth --no-input'
-    register: result
-    changed_when: "'No migrations to apply' not in result.stdout"
+    - name: Run database auth migrations
+      command: '{{ pulp_install_dir }}/bin/pulp-manager migrate auth --no-input'
+      register: result
+      changed_when: "'No migrations to apply' not in result.stdout"
 
-  - name: Run database migrations
-    command: '{{ pulp_install_dir }}/bin/pulp-manager migrate --no-input'
-    register: result
-    changed_when: "'No migrations to apply' not in result.stdout"
+    - name: Run database migrations
+      command: '{{ pulp_install_dir }}/bin/pulp-manager migrate --no-input'
+      register: result
+      changed_when: "'No migrations to apply' not in result.stdout"
 
-  - name: Set the Pulp admin user's password
-    command: '{{ pulp_install_dir }}/bin/pulp-manager reset-admin-password --password {{ pulp_default_admin_password }}'
-    no_log: true
-    when: pulp_default_admin_password is defined
-    changed_when: false  # This might be a lie.
+    - name: Set the Pulp admin user's password
+      command: '{{ pulp_install_dir }}/bin/pulp-manager reset-admin-password --password {{ pulp_default_admin_password }}'
+      no_log: true
+      when: pulp_default_admin_password is defined
+      changed_when: false  # This might be a lie.
 
   become: true
   become_user: '{{ pulp_user }}'

--- a/roles/pulp3-postgresql/vars/CentOS.yml
+++ b/roles/pulp3-postgresql/vars/CentOS.yml
@@ -1,1 +1,2 @@
+---
 pulp_psycopg_package: python-psycopg2

--- a/roles/pulp3-postgresql/vars/Fedora.yml
+++ b/roles/pulp3-postgresql/vars/Fedora.yml
@@ -1,1 +1,2 @@
+---
 pulp_psycopg_package: python3-psycopg2

--- a/roles/pulp3-postgresql/vars/main.yml
+++ b/roles/pulp3-postgresql/vars/main.yml
@@ -1,14 +1,15 @@
+---
 postgresql_databases:
-- name: '{{ pulp_database_config["default"]["NAME"] }}'
-  owner: '{{ pulp_database_config["default"]["NAME"] }}'
+  - name: '{{ pulp_database_config["default"]["NAME"] }}'
+    owner: '{{ pulp_database_config["default"]["NAME"] }}'
 
 postgresql_users:
-- name: '{{ pulp_database_config["default"]["NAME"] }}'
+  - name: '{{ pulp_database_config["default"]["NAME"] }}'
 
 postgresql_user_privileges:
-- name: '{{ pulp_database_config["default"]["NAME"] }}'
-  db: '{{ pulp_database_config["default"]["NAME"] }}'
-  priv: ALL
-  role_attr_flags: LOGIN
+  - name: '{{ pulp_database_config["default"]["NAME"] }}'
+    db: '{{ pulp_database_config["default"]["NAME"] }}'
+    priv: ALL
+    role_attr_flags: LOGIN
 
 postgresql_version: '9.6'

--- a/roles/pulp3-redis/meta/main.yml
+++ b/roles/pulp3-redis/meta/main.yml
@@ -1,12 +1,12 @@
-# Standards: 0.1
+---
 galaxy_info:
   author: Pulp
   description: Pulp Redis
   company: Red Hat
   min_ansible_version: 2.4
   platforms:
-  - name: Fedora
-    versions:
-    - 28
+    - name: Fedora
+      versions:
+        - 28
   license: GPL-3.0
 dependencies: []

--- a/roles/pulp3-redis/tasks/main.yml
+++ b/roles/pulp3-redis/tasks/main.yml
@@ -1,28 +1,28 @@
-# Standards: 0.1
 ---
 - name: Load OS specific variables
   include_vars: '{{ ansible_distribution }}.yml'
   tags:
-  - always
+    - always
 
 - block:
-  - name: Install requirements
-    package:
-      name: "{{ item }}"
-      state: present
-    with_items: "{{ pulp_preq_packages }}"
 
-  - name: Install Redis
-    package:
-      name: redis
-      state: present
+    - name: Install requirements
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ pulp_preq_packages }}"
 
-  - name: Start Redis
-    systemd:
-      name: redis
-      state: started
-      enabled: yes
-      daemon_reload: yes
+    - name: Install Redis
+      package:
+        name: redis
+        state: present
+
+    - name: Start Redis
+      systemd:
+        name: redis
+        state: started
+        enabled: yes
+        daemon_reload: yes
 
   become: true
 

--- a/roles/pulp3-redis/vars/CentOS.yml
+++ b/roles/pulp3-redis/vars/CentOS.yml
@@ -1,5 +1,5 @@
 ---
 pulp_preq_packages:
-- python36
-- python36-devel
+  - python36
+  - python36-devel
 pulp_python_interpreter: /usr/bin/python36

--- a/roles/pulp3-redis/vars/Fedora.yml
+++ b/roles/pulp3-redis/vars/Fedora.yml
@@ -1,5 +1,5 @@
 ---
 pulp_preq_packages:
-- python3
-- python3-devel
+  - python3
+  - python3-devel
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp3-resource-manager/defaults/main.yml
+++ b/roles/pulp3-resource-manager/defaults/main.yml
@@ -1,2 +1,3 @@
+---
 pulp_resource_manager_state: started
 pulp_resource_manager_enabled: true

--- a/roles/pulp3-resource-manager/handlers/main.yml
+++ b/roles/pulp3-resource-manager/handlers/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Restart pulp_resource_manager
   systemd:
     name: pulp_resource_manager.service

--- a/roles/pulp3-resource-manager/meta/main.yml
+++ b/roles/pulp3-resource-manager/meta/main.yml
@@ -1,14 +1,15 @@
-# Standards: 0.1
-# Depend on pulp3-redis for RQ.
+---
 galaxy_info:
   author: Pulp
   description: Pulp Resource Manager
   company: Red Hat
   min_ansible_version: 2.4
   platforms:
-  - name: Fedora
-    versions:
-    - 28
+    - name: Fedora
+      versions:
+        - 28
   license: GPL-3.0
+
+# Depend on pulp3-redis for RQ.
 dependencies:
-- role: pulp3-redis
+  - role: pulp3-redis

--- a/roles/pulp3-resource-manager/tasks/main.yml
+++ b/roles/pulp3-resource-manager/tasks/main.yml
@@ -1,19 +1,20 @@
+---
 - block:
 
-  - name: Install service files
-    template:
-      src: pulp_resource_manager.service.j2
-      dest: /etc/systemd/system/pulp_resource_manager.service
-      owner: root
-      group: root
-      mode: 0644
-    notify: Restart pulp_resource_manager
+    - name: Install service files
+      template:
+        src: pulp_resource_manager.service.j2
+        dest: /etc/systemd/system/pulp_resource_manager.service
+        owner: root
+        group: root
+        mode: 0644
+      notify: Restart pulp_resource_manager
 
-  - name: Set the pulp_resource_manager service state
-    systemd:
-      name: pulp_resource_manager.service
-      state: '{{ pulp_resource_manager_state }}'
-      enabled: '{{ pulp_resource_manager_enabled }}'
-      daemon_reload: true
+    - name: Set the pulp_resource_manager service state
+      systemd:
+        name: pulp_resource_manager.service
+        state: '{{ pulp_resource_manager_state }}'
+        enabled: '{{ pulp_resource_manager_enabled }}'
+        daemon_reload: true
 
   become: true

--- a/roles/pulp3-webserver/handlers/main.yml
+++ b/roles/pulp3-webserver/handlers/main.yml
@@ -1,3 +1,4 @@
+---
 - name: reload nginx
   systemd:
     name: nginx

--- a/roles/pulp3-webserver/meta/main.yml
+++ b/roles/pulp3-webserver/meta/main.yml
@@ -1,13 +1,12 @@
-# Standards: 0.1
+---
 galaxy_info:
   author: Pulp
   description: Pulp Web Server
   company: Red Hat
   min_ansible_version: 2.4
   platforms:
-  - name: Fedora
-    versions:
-    - 28
+    - name: Fedora
+      versions:
+        - 28
   license: GPL-3.0
 dependencies: []
-

--- a/roles/pulp3-webserver/tasks/main.yml
+++ b/roles/pulp3-webserver/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Find site-packages directory
   find:
     paths: '{{ pulp_install_dir }}'
@@ -16,35 +17,35 @@
 
 - block:
 
-  - name: Install Nginx
-    package:
-      name: nginx
-      state: present
+    - name: Install Nginx
+      package:
+        name: nginx
+        state: present
 
-  - name: Install Nginx configuration file
-    template:
-      src: nginx.conf
-      dest: /etc/nginx/nginx.conf
-    notify: reload nginx
+    - name: Install Nginx configuration file
+      template:
+        src: nginx.conf
+        dest: /etc/nginx/nginx.conf
+      notify: reload nginx
 
-  - name: Start and enable Nginx
-    systemd:
-      name: nginx
-      state: started
-      enabled: true
-      daemon_reload: true
+    - name: Start and enable Nginx
+      systemd:
+        name: nginx
+        state: started
+        enabled: true
+        daemon_reload: true
 
-  - name: Start and enable firewalld
-    systemd:
-      name: firewalld
-      state: started
-      enabled: true
+    - name: Start and enable firewalld
+      systemd:
+        name: firewalld
+        state: started
+        enabled: true
 
-  - name: Accept connections on port 80
-    firewalld:
-      service: http
-      permanent: true
-      immediate: true
-      state: enabled
+    - name: Accept connections on port 80
+      firewalld:
+        service: http
+        permanent: true
+        immediate: true
+        state: enabled
 
   become: true

--- a/roles/pulp3-workers/defaults/main.yml
+++ b/roles/pulp3-workers/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 pulp3_workers:
   1:
     state: started

--- a/roles/pulp3-workers/handlers/main.yml
+++ b/roles/pulp3-workers/handlers/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Reload systemd and restart pulp workers
   systemd:
     daemon_reload: true

--- a/roles/pulp3-workers/meta/main.yml
+++ b/roles/pulp3-workers/meta/main.yml
@@ -1,13 +1,13 @@
-# Standards: 0.1
+---
 galaxy_info:
   author: Pulp
   description: Pulp worker
   company: Red Hat
   min_ansible_version: 2.4
   platforms:
-  - name: Fedora
-    versions:
-    - 28
+    - name: Fedora
+      versions:
+        - 28
   license: GPL-3.0
 dependencies:
-- pulp3-redis
+  - pulp3-redis

--- a/roles/pulp3-workers/tasks/main.yml
+++ b/roles/pulp3-workers/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Install service files
   template:
     src: pulp_worker@.service.j2

--- a/roles/pulp3/handlers/main.yml
+++ b/roles/pulp3/handlers/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Restart pulp_wsgi.service
   systemd:
     name: pulp_wsgi.service

--- a/roles/pulp3/meta/main.yml
+++ b/roles/pulp3/meta/main.yml
@@ -1,4 +1,3 @@
-# Standards: 0.1
 ---
 galaxy_info:
   author: Pulp Team
@@ -8,13 +7,13 @@ galaxy_info:
   company: Red Hat
   min_ansible_version: 2.2
   platforms:
-  - name: Fedora
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - stretch
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - stretch
   galaxy_tags:
-  - pulp3
-  - pulpcore
+    - pulp3
+    - pulpcore
 dependencies: []

--- a/roles/pulp3/tasks/configure.yml
+++ b/roles/pulp3/tasks/configure.yml
@@ -1,3 +1,4 @@
+---
 - block:
 
   - name: Create configuration directory for Pulp

--- a/roles/pulp3/tasks/install.yml
+++ b/roles/pulp3/tasks/install.yml
@@ -1,69 +1,70 @@
+---
 - block:
 
-  - name: Install prerequisites
-    package:
-      name: '{{ pulp_preq_packages }}'
-      state: present
+    - name: Install prerequisites
+      package:
+        name: '{{ pulp_preq_packages }}'
+        state: present
 
-  - name: Disable SELinux (Pulp 3 is currently incompatible with SELinux)
-    selinux:
-      policy: targeted
-      state: permissive
+    - name: Disable SELinux (Pulp 3 is currently incompatible with SELinux)
+      selinux:
+        policy: targeted
+        state: permissive
 
-  # Become root so as to search paths like /usr/sbin.
-  - name: Find the nologin executable
-    command: which nologin
-    changed_when: False
-    check_mode: False
-    register: result
+    # Become root so as to search paths like /usr/sbin.
+    - name: Find the nologin executable
+      command: which nologin
+      changed_when: False
+      check_mode: False
+      register: result
 
-  - name: Create user {{ pulp_user }}
-    user:
-      name: '{{ pulp_user }}'
-      shell: '{{ result.stdout.strip() }}'
-      home: '{{ pulp_var_dir }}'
-      system: true
+    - name: Create user {{ pulp_user }}
+      user:
+        name: '{{ pulp_user }}'
+        shell: '{{ result.stdout.strip() }}'
+        home: '{{ pulp_var_dir }}'
+        system: true
 
-  - name: Create temp dir for Pulp
-    file:
-      path: '{{ pulp_var_dir }}/tmp'
-      state: directory
-      owner: '{{ pulp_user }}'
-      group: '{{ pulp_user }}'
-      mode: 0775
+    - name: Create temp dir for Pulp
+      file:
+        path: '{{ pulp_var_dir }}/tmp'
+        state: directory
+        owner: '{{ pulp_user }}'
+        group: '{{ pulp_user }}'
+        mode: 0775
 
-  - name: Create cache dir for Pulp
-    file:
-      path: '{{ pulp_cache_dir }}'
-      state: directory
-      owner: '{{ pulp_user }}'
-      group: '{{ pulp_user }}'
-      mode: 0775
+    - name: Create cache dir for Pulp
+      file:
+        path: '{{ pulp_cache_dir }}'
+        state: directory
+        owner: '{{ pulp_user }}'
+        group: '{{ pulp_user }}'
+        mode: 0775
 
-  - name: Create pulp install dir
-    file:
-      path: '{{ pulp_install_dir }}'
-      state: directory
-      owner: '{{ pulp_user }}'
-      group: '{{ pulp_user }}'
+    - name: Create pulp install dir
+      file:
+        path: '{{ pulp_install_dir }}'
+        state: directory
+        owner: '{{ pulp_user }}'
+        group: '{{ pulp_user }}'
 
   become: true
 
 - block:
 
-  - name: Install pulpcore
-    pip:
-      name: pulpcore
-      state: present
-      virtualenv: '{{ pulp_install_dir }}'
-      virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
+    - name: Install pulpcore
+      pip:
+        name: pulpcore
+        state: present
+        virtualenv: '{{ pulp_install_dir }}'
+        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
-  - name: Install Pulp plugins
-    pip:
-      name: '{{ pulp_install_plugins }}'
-      state: present
-      virtualenv: '{{ pulp_install_dir }}'
-      virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
+    - name: Install Pulp plugins
+      pip:
+        name: '{{ pulp_install_plugins }}'
+        state: present
+        virtualenv: '{{ pulp_install_dir }}'
+        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
   become: true
   become_user: '{{ pulp_user }}'

--- a/roles/pulp3/tasks/main.yml
+++ b/roles/pulp3/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Load OS specific variables
   include_vars: '{{ ansible_distribution }}.yml'
   tags:
-  - always
+    - always
 
 - import_tasks: install.yml
 - import_tasks: configure.yml

--- a/roles/pulp3/tasks/wsgi.yml
+++ b/roles/pulp3/tasks/wsgi.yml
@@ -1,3 +1,4 @@
+---
 - name: Install gunicorn
   pip:
     name: gunicorn

--- a/roles/pulp3/vars/CentOS.yml
+++ b/roles/pulp3/vars/CentOS.yml
@@ -1,8 +1,8 @@
 ---
 pulp_preq_packages:
-- python36
-- python36-devel
-- libselinux-python  # For ansible itself
-- python-psycopg2
-- python-contextlib2
+  - python36
+  - python36-devel
+  - libselinux-python  # For ansible itself
+  - python-psycopg2
+  - python-contextlib2
 pulp_python_interpreter: /usr/bin/python36

--- a/roles/pulp3/vars/Debian.yml
+++ b/roles/pulp3/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 pulp_preq_packages:
-- python3
-- python3-venv
+  - python3
+  - python3-venv

--- a/roles/pulp3/vars/Fedora.yml
+++ b/roles/pulp3/vars/Fedora.yml
@@ -1,8 +1,8 @@
 ---
 pulp_preq_packages:
-- python3
-- python3-devel
-- libselinux-python  # For ansible itself
+  - python3
+  - python3-devel
+  - libselinux-python  # For ansible itself
 
 # Pulp requires Python 3.5+.
 pulp_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
Letting a linter tell us what the proper formatting for code should be
eliminates a type of bike-shedding.

yamllint and ansible-review have different opinions about proper code
formatting. But yamllint is a much easier tool to use, and it's
available to us *right now*. We can figure out how to re-enable
ansible-review later, if desired.