### PR TITLE
Add Python 3.7 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # Molecule runs tests in containers.
 sudo: required
+# By default, Traivs provides Ubuntu 14.04 VMs. We specify a newer release so
+# that Python 3.7 can be used in testing.
+dist: xenial
 services:
 - docker
 
@@ -14,6 +17,8 @@ matrix:
     env: TOXENV=py27
   - python: 3.6
     env: TOXENV=py36
+  - python: 3.7
+    env: TOXENV=py37
 install:
 - pip install --upgrade pip
 - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# As of this writing, molecule only supports Python 2.7 and 3.6.
-envlist = py{27,36}
+envlist = py{27,36,37}
 # This repo isn't a Python project, so it makes no sense to install an sdist
 # into the virtualenvs tox creates.
 skipsdist = true


### PR DESCRIPTION
Molecule 2.17 adds support for Python 3.7. See:
https://molecule.readthedocs.io/en/latest/changelog.html