### PR TITLE
Specify python interpreter in Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Knowledge of [Ansible](https://www.ansible.com/) is not necessary for the
 [Vagrant](https://www.vagrantup.com/) installed, but will be very helpful for
 installations that go beyond the default configuration.
 
+Required Variables
+------------------
+
+Each role documents its own variables. Most have sane defaults, but a few are required.
+
+
 User Installation
 -----------------
 

--- a/Vagrantfile.sandbox.example
+++ b/Vagrantfile.sandbox.example
@@ -16,6 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "pulp_roles", type: 'ansible', run: "always" do |ansible|
     ansible.galaxy_role_file = "requirements.yml"
     ansible.playbook = "user-sandbox.yml"
+    ansible.extra_vars = {"ansible_python_interpreter": "/usr/bin/python3"}
     # ansible.verbose = "vvv"
   end
 

--- a/Vagrantfile.source.example
+++ b/Vagrantfile.source.example
@@ -33,6 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "pulp_roles", type: 'ansible', run: "always" do |ansible|
     ansible.galaxy_role_file = "requirements.yml"
     ansible.playbook = "source-install.yml"
+    ansible.extra_vars = {"ansible_python_interpreter": "/usr/bin/python3"}
       # ansible.verbose = "vvv"
       # ansible.start_at_task = "ansible task name here"
   end

--- a/roles/pulp3-postgresql/README.md
+++ b/roles/pulp3-postgresql/README.md
@@ -22,6 +22,8 @@ Role Variables:
 Shared Variables:
 -----------------
 
+* `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+
 This role **is tightly coupled** with the required the `pulp3` role and uses some of
 variables which are documented in that role:
 

--- a/roles/pulp3-redis/README.md
+++ b/roles/pulp3-redis/README.md
@@ -6,6 +6,8 @@ Install and start Redis, and install RQ in the Pulp virtualenv.
 Shared Variables:
 -----------------
 
+* `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+
 This role is **not tightly coupled** to the `pulp3` role, but uses some of the same
 variables. When used in the same play, the values are inherited from the `pulp3`
 role. When not used together, this role provides identical defaults.

--- a/roles/pulp3-resource-manager/README.md
+++ b/roles/pulp3-resource-manager/README.md
@@ -14,6 +14,8 @@ Configurable Variables:
 Shared variables:
 -----------------
 
+* `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+
 This role **is not tightly coupled** with the `pulp3-postgresql` role, but it does
 use some of the same variables. When used together, the values are inherited from
 the role. When not used together, these values are **required**.

--- a/roles/pulp3-webserver/README.md
+++ b/roles/pulp3-webserver/README.md
@@ -9,6 +9,8 @@ future, additional web servers such as Apache or LightTPD might be supported.
 Shared variables:
 -----------------
 
+* `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+
 This role is **not tightly coupled** to the `pulp3` role, but uses some of the same
 variables. When used in the same play, the values are inherited from the `pulp3`
 role.

--- a/roles/pulp3-workers/README.md
+++ b/roles/pulp3-workers/README.md
@@ -13,6 +13,8 @@ Configurable Variables:
 Shared variables:
 -----------------
 
+* `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+
 This role **is not tightly coupled** with the `pulp3-postgresql` role, but it does
 use some of the same variables. When used together, the values are inherited from
 the role. When not used together, these values are **required**.

--- a/roles/pulp3/README.md
+++ b/roles/pulp3/README.md
@@ -39,6 +39,8 @@ Role Variables:
 Shared Variables:
 -----------------
 
+* `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+
 This role is required by the `pulp3-postgresql` role and uses variables that
 are defined and documented in that role:
 


### PR DESCRIPTION
Originally, I had intended the source-install.yml playbook to be a
"working base" playbook, designed to be used only by
Vagrantfile.source.example. However, that playbook could be more useful
if it were agnostic to OS.

I had hoped to avoid putting variables in the Vagrantfile, but since this one is OS specific, I don't know of a better place for this. Even so, that will be a temporary complexity-- when we move the roles out of a single repository, the Vagrantfile(s) and the playbooks will likely move to another repo, possibly pulp/devel. At that point, it will be more reasonable for the playbooks to be coupled to Vagrantfiles.

@ehelms sorry I missed the docs for this var. I went role by role, and this one isn't used by the roles :)

fixes #4111