### PR TITLE
Switch to geerlingguy.postgresql role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /*.retry
 .tox
 **/*.pyc
-/roles/ANXS.postgresql
+/roles/geerlingguy.postgresql
 
 # Ignores for Vagrant related items
 .vagrant/

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
-- src: https://github.com/ANXS/postgresql
-  version: master
-  name: ANXS.postgresql
+- src: https://github.com/ehelms/ansible-role-postgresql
+  version: add-scl-support
+  name: geerlingguy.postgresql

--- a/roles/pulp3-postgresql/defaults/main.yml
+++ b/roles/pulp3-postgresql/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-pulp_postgresql_call_anxs_postgresql: true
 pulp_database_config:
   default:
     HOST: localhost
     ENGINE: django.db.backends.postgresql_psycopg2
     NAME: pulp
     USER: pulp
+    PASSWORD: pulp

--- a/roles/pulp3-postgresql/handlers/main.yml
+++ b/roles/pulp3-postgresql/handlers/main.yml
@@ -1,8 +1,4 @@
 ---
-# This is a hack to workaround an inheritance problem with "become". These handlers
-# are from the ANXS.postgresql role, but despite running that role with become: true,
-# these handlers are not. We override them here with explicit "become: true", which
-# seems to clobber the ANXS version, and the permsissions all work out.
 - name: restart postgresql with service
   service:
     name: "{{ postgresql_service_name }}"

--- a/roles/pulp3-postgresql/tasks/main.yml
+++ b/roles/pulp3-postgresql/tasks/main.yml
@@ -6,17 +6,15 @@
 
 - block:
 
-    # See: https://github.com/ANXS/postgresql/pull/371
-    - name: Install psycopg package
+    - name: Install SCL package
       package:
-        name: '{{ pulp_psycopg_package }}'
+        name: 'centos-release-scl'
         state: present
+      when: ansible_distribution == 'CentOS'
 
-    # See: https://github.com/ANXS/postgresql/pull/376
     - name: Install and configure PostgreSQL
       import_role:
-        name: ANXS.postgresql
-      when: pulp_postgresql_call_anxs_postgresql
+        name: geerlingguy.postgresql
 
     - meta: flush_handlers
 

--- a/roles/pulp3-postgresql/vars/CentOS.yml
+++ b/roles/pulp3-postgresql/vars/CentOS.yml
@@ -1,2 +1,2 @@
 ---
-pulp_psycopg_package: python-psycopg2
+postgresql_python_library: python-psycopg2

--- a/roles/pulp3-postgresql/vars/Fedora.yml
+++ b/roles/pulp3-postgresql/vars/Fedora.yml
@@ -1,2 +1,2 @@
 ---
-pulp_psycopg_package: python3-psycopg2
+postgresql_python_library: python3-psycopg2

--- a/roles/pulp3-postgresql/vars/main.yml
+++ b/roles/pulp3-postgresql/vars/main.yml
@@ -1,17 +1,11 @@
 ---
-# Variables used by the ANXS Postgresql role
+# Variables used by the Geerlingguy Postgresql role
 
 postgresql_databases:
-    - name: '{{ pulp_database_config["default"]["NAME"] }}'
-      owner: '{{ pulp_database_config["default"]["USER"] }}'
+  - name: '{{ pulp_database_config["default"]["NAME"] }}'
 
 postgresql_users:
-    - name: '{{ pulp_database_config["default"]["USER"] }}'
-
-postgresql_user_privileges:
-    - name: '{{ pulp_database_config["default"]["USER"] }}'
-      db: '{{ pulp_database_config["default"]["NAME"] }}'
-      priv: ALL
-      role_attr_flags: LOGIN
-
-postgresql_version: '9.6'
+  - name: '{{ pulp_database_config["default"]["USER"] }}'
+    password: '{{ pulp_database_config["default"]["PASSWORD"] }}'
+    db: '{{ pulp_database_config["default"]["NAME"] }}'
+    priv: ALL

--- a/roles/pulp3-resource-manager/templates/pulp_resource_manager.service.j2
+++ b/roles/pulp3-resource-manager/templates/pulp_resource_manager.service.j2
@@ -4,8 +4,8 @@ After=network-online.target
 Wants=network-online.target
 
 # This service will break if left running while PostgreSQL restarts.
-BindsTo=postgresql-{{ postgresql_version}}.service
-After=postgresql-{{ postgresql_version}}.service
+BindsTo=postgresql.service
+After=postgresql.service
 
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"

--- a/roles/pulp3-workers/templates/pulp_worker@.service.j2
+++ b/roles/pulp3-workers/templates/pulp_worker@.service.j2
@@ -4,8 +4,8 @@ After=network-online.target
 Wants=network-online.target
 
 # This service will break if left running while PostgreSQL restarts.
-BindsTo=postgresql-{{ postgresql_version}}.service
-After=postgresql-{{ postgresql_version}}.service
+BindsTo=postgresql.service
+After=postgresql.service
 
 [Service]
 EnvironmentFile=-/etc/default/pulp_workers


### PR DESCRIPTION
The previous ANXS role made limited assumptions about how and where
to get Postgres. Further, the last commit on the git repo was 6 months
ago at the time of this commit. The idea is to move to a more active
role that support for using SCL based postgres can be added to.

This currently points at a fork to get the Fedora and SCL support.