### PR TITLE
Postgres needs psycopg2 (for Python2) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ node user.
 
 ```
 ansible-galaxy install -r requirements.yml
-ansible-playbook user-sandbox.yml -u <managed_node_username> --ask-become-pass
+ansible-playbook user-sandbox.yml -u <managed_node_username> --ask-become-pass -e ansible_python_interpreter=/usr/bin/python3
 ```
 
 To configure a custom install, you will need to set configuration variables. In

--- a/roles/pulp3-postgresql/tasks/main.yml
+++ b/roles/pulp3-postgresql/tasks/main.yml
@@ -12,6 +12,12 @@
         state: present
       when: ansible_distribution == 'CentOS'
 
+    - name: Install psycopg2 package
+      package:
+        name: 'python2-psycopg2'
+        state: present
+      when: ansible_distribution == 'Fedora'
+
     - name: Install and configure PostgreSQL
       import_role:
         name: geerlingguy.postgresql

--- a/roles/pulp3-postgresql/tasks/main.yml
+++ b/roles/pulp3-postgresql/tasks/main.yml
@@ -12,6 +12,8 @@
         state: present
       when: ansible_distribution == 'CentOS'
 
+      # Workaround geerlingguy issue
+      # https://github.com/geerlingguy/ansible-role-postgresql/issues/48
     - name: Install psycopg2 package
       package:
         name: 'python2-psycopg2'


### PR DESCRIPTION
Postgres from `geerlingguy` needs python2-psycopg2 and it is not installing it on Fedora hosts.
NOTE: The package is needed for Python2 because internally postgres uses Python2 to run its modules.

also on Fedora 28 `-e ansible_python_interpreter=/usr/bin/python3` is needed so ansible can use the firewalld and other modules.

With that 2 changes this playbook works well on Fedora 28

```bash
$ ansible-playbook -i fedora-28-pulp-3, -u root --ask-become-pass user-sandbox.yml -e ansible_python_interpreter=/usr/bin/python3
...
...
PLAY RECAP ************************
fedora-28-pulp-3           : ok=73   changed=43   unreachable=0    failed=0  
```