### PR TITLE
Add full-source-install.yml install pulp3 w/ all available plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ can rerun the playbook with `vagrant provision`.
 Source Installation:
 --------------------
 
+### With vagrant:
+
 This section will provide a Vagrant machine with editable source installs of
 Pulp and the file plugin.
 
@@ -131,6 +133,23 @@ Create your Vagrantfile and use it.
 $ cp Vagrantfile.source.example Vagrantfile
 $ vagrant up
 ```
+
+### From git repositories:
+
+This playbook will install pulp and plugins by cloning directly from defined git repositories.
+
+First, you will need to configure ssh between your control node and your
+managed node. When you can ssh into the managed node without a password, you
+are ready to move to the next step.
+
+```
+ansible-galaxy install -r requirements.yml
+ansible-playbook -i <hostname-or-ip-address>, -u <managed_node_username> --ask-become-pass full-source-install.yml
+```
+
+To configure a custom install, for example, specifying custom git repositories or extra tasks for plugin installations, you will need to set configuration variables in the playbook, `full-source-install.yml`.
+
+Plugin specific pre install taks can be defined as in the example `plugin-pulp-rpm-pretask.yml`.
 
 Development
 -----------

--- a/full-source-install.yml
+++ b/full-source-install.yml
@@ -1,0 +1,36 @@
+# ansible-playbook -i hostname-or-ip, -u root --ask-become-pass full-source-install.yml
+---
+- hosts: all
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    pulp_source_dir: "/pulp_source/pulp"
+    pulp_git_repo: https://github.com/pulp/pulp.git
+    pulp_secret_key: "unsafe_default"
+    pulp_default_admin_password: admin
+    pulp_debug: true
+    pulp_install_plugins:
+      pulp-docker:
+        app_label: "pulp_docker"
+        source_dir: "/pulp_source/pulp_docker"
+        git_repo: https://github.com/pulp/pulp_docker.git
+      pulp-file:
+        app_label: "pulp_file"
+        source_dir: "/pulp_source/pulp_file"
+        git_repo: https://github.com/pulp/pulp_file.git
+      pulp-python:
+        app_label: "pulp_python"
+        source_dir: "/pulp_source/pulp_python"
+        git_repo: https://github.com/pulp/pulp_python.git
+      pulp-rpm:
+        app_label: "pulp_rpm"
+        source_dir: "/pulp_source/pulp_rpm"
+        git_repo: https://github.com/pulp/pulp_rpm.git
+        pre_task_file: plugin-pulp-rpm-pretask.yml
+  pre_tasks:
+    - name: Set up machine for full plugin source installs
+      include: full-source-pretask.yml
+  roles:
+    - pulp3-postgresql
+    - pulp3-workers
+    - pulp3-resource-manager
+    - pulp3-webserver

--- a/full-source-pretask.yml
+++ b/full-source-pretask.yml
@@ -1,0 +1,30 @@
+# NOTE:  Pip should be able to write to /pulp_source/* directories
+#        so 0777 permission is set for that reason.
+---
+- block:
+
+    - name: Install git
+      package: name=git state=present
+
+    - name: Create source folder
+      file: path=/pulp_source state=directory mode=0777
+
+    - name: Clone pulp source repository
+      git:
+        repo: '{{ pulp_git_repo }}'
+        dest: '{{ pulp_source_dir }}'
+        force: true
+      when: pulp_git_repo is defined
+
+    - name: Clone plugins source repositories
+      git:
+        repo: '{{ item.value.git_repo }}'
+        dest: '{{ item.value.source_dir }}'
+        force: true
+      with_dict: '{{ pulp_install_plugins }}'
+      when: pulp_install_plugins[item.key].git_repo is defined
+
+    - name: set permissions
+      shell: chmod -R 0777 /pulp_source/*
+
+  become: true

--- a/plugin-pulp-rpm-pretask.yml
+++ b/plugin-pulp-rpm-pretask.yml
@@ -1,0 +1,41 @@
+# https://pulp-rpm.readthedocs.io/en/latest/installation.html#install-createrepo-c-from-source
+---
+- block:
+
+    - name: Install pre-requisites for pulp-rpm installation
+      package: name={{ item }} state=present
+      loop:
+        - gcc
+        - make
+        - cmake
+        - bzip2-devel
+        - expat-devel
+        - file-devel
+        - glib2-devel
+        - libcurl-devel
+        - libxml2-devel
+        - python3-devel
+        - rpm-devel
+        - openssl-devel
+        - sqlite-devel
+        - xz-devel
+        - zlib-devel
+
+  become: true
+  become_user: root
+
+- block:
+
+    - name: Install createrepo_c for pulp-rpm plugin
+      pip:
+        name: '{{ item }}'
+        state: latest
+        virtualenv: '{{ pulp_install_dir }}'
+        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
+      loop:
+        - pip
+        - scikit-build
+      when: "'pulp-rpm' in pulp_install_plugins"
+
+  become: true
+  become_user: '{{ pulp_user }}'

--- a/roles/pulp3/README.md
+++ b/roles/pulp3/README.md
@@ -23,9 +23,16 @@ Role Variables:
   of each plugin. **Required**.
   * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
+  * `pre_task_file`: Optional. Name of the task file to be executed before the
+  plugin is installed.
+  * `git_repo`: Optional. Used only with `full-source-install.yml` playbook,
+  when defined this git repo will be cloned to `source_dir`.
 * `pulp_install_wsgi_service`: Whether to create systemd service files for
   pulp_wsgi. Defaults to "true".
 * `pulp_secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
+* `pulp_debug`: Optional. Pulp's Django application `DEBUG` variable.
+* `pulp_git_repo`: Optional. Used only with `full-source-install.yml` playbook,
+  when defined this git repo will be cloned to `pulp_source_dir`.
 * `pulp_source_dir`: Optional. Absolute path to Pulp source code. If present, Pulp
   will be installed from source in editable mode.
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".

--- a/roles/pulp3/tasks/install.yml
+++ b/roles/pulp3/tasks/install.yml
@@ -69,6 +69,13 @@
         - plugin
       when: pulp_source_dir is defined
 
+    - name: Include plugin specific pre tasks
+      include_tasks: "{{ plugin.value.pre_task_file }}"
+      with_dict: '{{ pulp_install_plugins }}'
+      when: pulp_install_plugins[plugin.key].pre_task_file is defined
+      loop_control:
+        loop_var: plugin
+
     - name: Install Pulp plugins via PyPI
       pip:
         name: '{{ item.key }}'

--- a/roles/pulp3/templates/settings.py.j2
+++ b/roles/pulp3/templates/settings.py.j2
@@ -1,3 +1,7 @@
 DATABASES = {{ pulp_database_config | to_json }}
 
 SECRET_KEY = '{{ pulp_secret_key }}'
+
+{% if pulp_debug is defined %}
+DEBUG = True
+{% endif %}


### PR DESCRIPTION
The `full-source-install.yml` installs pulp3 with plugins:

- docker
- python
- file
- rpm

> NOTE: added a task to install `createrepo_c` from repo for pulp-rpm

`ansible-playbook -i hostname-or-ip, -u root --ask-become-pass full-source-install.yml`

Tested on Fedora 28 VMs, this playbook will be useful to setup CI for QE.

> **NOTE**: when `ansible-pulp3`  is available on ansible-galaxy we can move this playbook to pulp-ci