### PR TITLE
Adds pip_editable variable to control how pip installs from source

### DIFF
--- a/roles/pulp3/defaults/main.yml
+++ b/roles/pulp3/defaults/main.yml
@@ -10,3 +10,4 @@ pulp_user: pulp
 pulp_var_dir: '/var/lib/pulp'
 pulp_wsgi_enabled: true
 pulp_wsgi_state: started
+pulp_pip_editable: yes

--- a/roles/pulp3/tasks/install.yml
+++ b/roles/pulp3/tasks/install.yml
@@ -68,7 +68,7 @@
     - name: Install pulpcore package from source
       pip:
         name: '{{ pulp_source_dir }}'
-        editable: yes
+        editable: '{{ pulp_pip_editable }}'
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       when: pulp_source_dir is defined
@@ -76,7 +76,7 @@
     - name: Install pulpcore-plugin package from source
       pip:
         name: '{{ pulp_plugin_source_dir }}'
-        editable: yes
+        editable: '{{ pulp_pip_editable }}'
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       when: pulp_plugin_source_dir is defined
@@ -93,7 +93,7 @@
     - name: Install Pulp plugins from source
       pip:
         name: '{{ item.value.source_dir }}'
-        editable: yes
+        editable: '{{ pulp_pip_editable }}'
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       with_dict: '{{ pulp_install_plugins }}'


### PR DESCRIPTION
When installing from source using a local directory or directly from a github
URL it is sometimes needed to control if pip is using `-e` mode.

This instroduces the `pulp_pip_editable` variable to be overriden in
external playbooks consuming this roles.

One example is QE install playbook which installs from `http://github..../tarball/master` and then cannot use the editable mode: https://github.com/PulpQE/pulp-qe-tools/tree/master/pulp3/install_pulp3#manually

With this new variable it would be easy to override passing `-e pulp_pip_editable=no`