### PR TITLE
Install minimal set of packages in new pulp3-devel role

### DIFF
--- a/roles/pulp3-devel/tasks/main.yml
+++ b/roles/pulp3-devel/tasks/main.yml
@@ -8,8 +8,6 @@
           - dnf-utils
           - dstat
           - fd-find
-          - fedora-easy-karma
-          - fpaste
           - fzf
           - git
           - htop
@@ -19,18 +17,15 @@
           - jq
           - ncdu
           - python-django-bash-completion
-          - python-ipdb
-          - python-rpdb
           - python3-setuptools
           - python3-virtualenvwrapper
           - redhat-lsb-core
           - ripgrep
           - screen
-          - telnet
           - tmux
           - tree
-          - wget
           - vim-enhanced
+          - wget
         state: present
       retries: "{{ package_retries }}"
       register: result

--- a/roles/pulp3-devel/templates/alias.bashrc.j2
+++ b/roles/pulp3-devel/templates/alias.bashrc.j2
@@ -28,18 +28,9 @@ pstatus() {
 }
 _pstatus_help="Report the status of all pulp-related services"
 
-preset() {
-    echo "Due to its similarity to 'prestart', 'preset' has been renamed to 'pclean'."
-    echo "Please use 'pclean' instead, and remember to update any script that might be calling it."
-    sleep 3
-    pclean
-}
-# intentionally undocumented, only list pclean in help for this
-
 pclean() {
     workon pulp
     pulp-manager reset_db --noinput
-    pulp-manager migrate auth --noinput
     pulp-manager migrate
     pulp-manager reset-admin-password --password admin
 }
@@ -92,5 +83,3 @@ phelp() {
     setterm -default
 }
 _phelp_help="Print this help"
-
-alias phttp="http"

--- a/source-install.yml
+++ b/source-install.yml
@@ -1,13 +1,9 @@
 ---
 - hosts: all
   vars:
-    package_retries: "5"
-    pulp_source_dir: "/home/vagrant/devel/pulp"
-    pulp_plugin_source_dir: "/home/vagrant/devel/pulpcore-plugin"
-    pulp_secret_key: "unsafe_default"
     developer_user: "vagrant"
-    pulp_create_user: false
     developer_user_home: "/home/vagrant"
+    package_retries: "5"
     pulp_default_admin_password: password
     pulp_install_plugins:
       # pulp-python:
@@ -16,6 +12,9 @@
       pulp-file:
         app_label: "pulp_file"
         source_dir: "/home/vagrant/devel/pulp_file"
+    pulp_plugin_source_dir: "/home/vagrant/devel/pulpcore-plugin"
+    pulp_secret_key: "unsafe_default"
+    pulp_source_dir: "/home/vagrant/devel/pulp"
     supplement_bashrc: true
   pre_tasks:
     - name: Set up Vagrant machine for source installs


### PR DESCRIPTION
Remove packages not used by everyone, or outdated no longer required.
Alphabetize vars list in source-install.yml as it's grown in length.
Remove preset and phttp from aliases.

fixes #4322
https://pulp.plan.io/issues/4322