### PR TITLE
Adds `pulp_content_host` variable to specify custom hostname and port

### DIFF
--- a/roles/pulp3-content/README.md
+++ b/roles/pulp3-content/README.md
@@ -3,6 +3,13 @@ pulp3-content
 
 Install, configure, and set the state of pulp content app.
 
+Variables:
+----------
+
+* `pulp_content_host`: **Optional**. host and port where Pulp content app is served.
+
+This variable will be set as the value of `CONTENT_HOST` config in `{{pulp_config_dir}}/settings.py` as the base path to build content URLs and also is the value passed to the `--bind` parameter of the `pulpcore.content` gunicorn service.
+
 Shared variables:
 -----------------
 

--- a/roles/pulp3-content/defaults/main.yml
+++ b/roles/pulp3-content/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+pulp_content_host: 'localhost:8080'

--- a/roles/pulp3-content/templates/pulp_content_app.service.j2
+++ b/roles/pulp3-content/templates/pulp_content_app.service.j2
@@ -13,7 +13,7 @@ User={{ pulp_user }}
 WorkingDirectory=/var/run/pulp_content_app/
 RuntimeDirectory=pulp_content_app
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.content:server \
-          --bind 'localhost:8080' \
+          --bind '{{ pulp_content_host }}' \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w 2
 

--- a/roles/pulp3/templates/settings.py.j2
+++ b/roles/pulp3/templates/settings.py.j2
@@ -1,3 +1,7 @@
 DATABASES = {{ pulp_database_config | to_json }}
 
 SECRET_KEY = '{{ pulp_secret_key }}'
+
+{% if pulp_content_host is defined %}
+CONTENT_HOST = '{{ pulp_content_host }}'
+{% endif %}


### PR DESCRIPTION
Adds `pulp_content_host` variable to specify custom hostname and port for `CONTENT_HOST` server app bindings.

closes #4352
https://pulp.plan.io/issues/4352