### PR TITLE
Fix multiple errors, get travis passing

### DIFF
--- a/molecule/source/prepare.yml
+++ b/molecule/source/prepare.yml
@@ -8,6 +8,12 @@
           - git
         state: present
 
+    - name: Create user {{ developer_user }}
+      user:
+        name: '{{ developer_user }}'
+        home: '{{ developer_user_home }}'
+      when: developer_user is defined
+
     - name: Clone pulp repository
       git:
         repo: 'https://github.com/pulp/pulp.git'

--- a/roles/pulp3-devel/tasks/main.yml
+++ b/roles/pulp3-devel/tasks/main.yml
@@ -53,7 +53,6 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
-
     - name: Install requirements for testing locally
       pip:
         requirements: '{{ pulp_source_dir }}/test_requirements.txt'
@@ -68,9 +67,10 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
-      retries: "{{ package_retries }}"
+      retries: "{{ pulp_devel_package_retries }}"
       register: result
       until: result is succeeded
+      notify: Collect static content
 
   become: true
   become_user: '{{ pulp_user }}'
@@ -142,7 +142,7 @@
 
   become: true
   become_user: "{{ developer_user }}"
-#
+
 - block:
 
     - name: Set the message of the day

--- a/roles/pulp3/handlers/main.yml
+++ b/roles/pulp3/handlers/main.yml
@@ -5,3 +5,10 @@
     state: restarted
     daemon_reload: true
   become: true
+
+- name: Collect static content
+  command: '{{ pulp_install_dir }}/bin/pulp-manager collectstatic --noinput --link'
+  register: staticresult
+  changed_when: "staticresult.stdout is not search('\n0 static files')"
+  become: true
+  become_user: '{{ pulp_user }}'

--- a/roles/pulp3/tasks/configure.yml
+++ b/roles/pulp3/tasks/configure.yml
@@ -19,10 +19,3 @@
       force: no
 
   become: true
-
-- name: Collect static content for docs and browsable API
-  command: '{{ pulp_install_dir }}/bin/pulp-manager collectstatic --noinput --link'
-  register: staticresult
-  changed_when: "staticresult.stdout is not search('\n0 static files')"
-  become: true
-  become_user: '{{ pulp_user }}'

--- a/roles/pulp3/tasks/install.yml
+++ b/roles/pulp3/tasks/install.yml
@@ -77,6 +77,7 @@
       # This is a hack. Editable pip installs are always changed, which fails molecule's
       # idempotence test.
       changed_when: result.changed and not pulp_pip_editable
+      notify: Collect static content
 
     - name: Install pulpcore-plugin package from source
       pip:
@@ -89,6 +90,7 @@
       # This is a hack. Editable pip installs are always changed, which fails molecule's
       # idempotence test.
       changed_when: result.changed and not pulp_pip_editable
+      notify: Collect static content
 
     - name: Install Pulp plugins via PyPI
       pip:
@@ -98,6 +100,7 @@
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       with_dict: '{{ pulp_install_plugins }}'
       when: pulp_install_plugins[item.key].source_dir is undefined
+      notify: Collect static content
 
     - name: Install Pulp plugins from source
       pip:
@@ -111,6 +114,7 @@
       # This is a hack. Editable pip installs are always changed, which fails molecule's
       # idempotence test.
       changed_when: result.changed and not pulp_pip_editable
+      notify: Collect static content
 
   become: true
   become_user: '{{ pulp_user }}'


### PR DESCRIPTION
1. Create a user for molecule in the "source" scenario. This fix isn't
ideal-- we need to make more adjustments to the users generally, but
there were multiple problems with the direct approach. Ideally for a
dev install, the developer could simply set the `pulp_user` to their
user, which is expected to exist on the managed node. However this
approach broke the pulplift installation. I'm sure it will work, we just
need to try again when everything else is already working.

2. Minor fix: incorrect var name in pulp3-devel. Failure was hidden by
the first test failure.

3. Move collectstatic to handler. Multiple events cause static files to
be collected, so it makes more sense for this to be a handler. This
fixes idempotence tests, which again were hidden by the previous errors.
This was only an issue for installations that use the pulp3-devel role.
[noissue]