### PR TITLE
Transition pulp to pulpcore git repo

### DIFF
--- a/example-source/group_vars/all
+++ b/example-source/group_vars/all
@@ -1,7 +1,7 @@
 ---
 pulp_default_admin_password: password
 pulp_secret_key: secret
-pulp_source_dir: '/var/lib/pulp/devel/pulp'
+pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_plugin_source_dir: "/var/lib/pulp/devel/pulpcore-plugin"
 pulp_install_plugins:
   pulp-file:

--- a/molecule/source/prepare.yml
+++ b/molecule/source/prepare.yml
@@ -15,7 +15,7 @@
 
     - name: Clone pulp repository
       git:
-        repo: 'https://github.com/pulp/pulp.git'
+        repo: 'https://github.com/pulp/pulpcore.git'
         dest: '{{ pulp_source_dir }}'
         update: yes
 


### PR DESCRIPTION
The transition only affects source installations, PyPI installations
remain unchanged.

re #4444