### PR TITLE
Problem: installer depends on non-existing pulp-manager

### DIFF
--- a/example-source/playbook.yml
+++ b/example-source/playbook.yml
@@ -7,3 +7,5 @@
     - pulp3-webserver
     - pulp3-content
     - pulp3-devel
+  environment:
+    DJANGO_SETTINGS_MODULE: pulpcore.app.settings

--- a/example-use/playbook.yml
+++ b/example-use/playbook.yml
@@ -6,3 +6,5 @@
     - pulp3-resource-manager
     - pulp3-webserver
     - pulp3-content
+  environment:
+    DJANGO_SETTINGS_MODULE: pulpcore.app.settings

--- a/roles/pulp3-devel/templates/alias.bashrc.j2
+++ b/roles/pulp3-devel/templates/alias.bashrc.j2
@@ -30,9 +30,9 @@ _pstatus_help="Report the status of all pulp-related services"
 
 pclean() {
     workon pulp
-    pulp-manager reset_db --noinput
-    pulp-manager migrate
-    pulp-manager reset-admin-password --password {{ pulp_default_admin_password }}
+    django-admin reset_db --noinput
+    django-admin migrate
+    django-admin reset-admin-password --password {{ pulp_default_admin_password }}
 }
 _pclean_help="Restore pulp to a clean-installed state"
 # can get away with not resetting terminal settings here since it gets reset in phelp

--- a/roles/pulp3-devel/templates/venv.bashrc.j2
+++ b/roles/pulp3-devel/templates/venv.bashrc.j2
@@ -6,3 +6,5 @@ export PIP_RESPECT_VIRTUALENV=true
 # make sure python3 is used in virtual environments
 export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
 source /usr/bin/virtualenvwrapper-3.sh
+# Configure settings for django-admin
+export DJANGO_SETTINGS_MODULE=pulpcore.app.settings

--- a/roles/pulp3-postgresql/tasks/main.yml
+++ b/roles/pulp3-postgresql/tasks/main.yml
@@ -63,23 +63,23 @@
       when: pulp_install_plugins[item].source_dir is undefined
 
     - name: Create database migrations for plugins
-      command: '{{ pulp_install_dir }}/bin/pulp-manager makemigrations {{ pulp_install_plugins[item].app_label}}'
+      command: '{{ pulp_install_dir }}/bin/django-admin makemigrations {{ pulp_install_plugins[item].app_label}}'
       with_items: "{{ pulp_install_plugins }}"
       register: result
       changed_when: "'No changes detected in app' not in result.stdout"
 
     - name: Run database auth migrations
-      command: '{{ pulp_install_dir }}/bin/pulp-manager migrate auth --no-input'
+      command: '{{ pulp_install_dir }}/bin/django-admin migrate auth --no-input'
       register: migrate_auth
       changed_when: "'No migrations to apply' not in migrate_auth.stdout"
 
     - name: Run database migrations
-      command: '{{ pulp_install_dir }}/bin/pulp-manager migrate --no-input'
+      command: '{{ pulp_install_dir }}/bin/django-admin migrate --no-input'
       register: result
       changed_when: "'No migrations to apply' not in result.stdout"
 
     - name: Set the Pulp admin user's password
-      command: '{{ pulp_install_dir }}/bin/pulp-manager reset-admin-password --password {{ pulp_default_admin_password }}'
+      command: '{{ pulp_install_dir }}/bin/django-admin reset-admin-password --password {{ pulp_default_admin_password }}'
       no_log: true
       when: pulp_default_admin_password is defined and migrate_auth.changed
 

--- a/roles/pulp3/handlers/main.yml
+++ b/roles/pulp3/handlers/main.yml
@@ -7,7 +7,7 @@
   become: true
 
 - name: Collect static content
-  command: '{{ pulp_install_dir }}/bin/pulp-manager collectstatic --noinput --link'
+  command: '{{ pulp_install_dir }}/bin/django-admin collectstatic --noinput --link'
   register: staticresult
   changed_when: "staticresult.stdout is not search('\n0 static files')"
   become: true


### PR DESCRIPTION
Solution: use django-admin directly

This patch updates the installer to use djang-admin binary instead of pulp-manager.

re: #4450
https://pulp.plan.io/issues/4450